### PR TITLE
Execute a command if given in the command line

### DIFF
--- a/pinito.pl
+++ b/pinito.pl
@@ -205,6 +205,12 @@ chdir "/";
 setup_signal_handling();
 render_templates();
 
+# If anything is given in the command line arguments, then execute it instead
+if (scalar @ARGV > 0) {
+    exec { $ARGV[0] } @ARGV;
+    exit 1;
+}
+
 my $syslog_server = setup_syslog_server if (SYSLOG_SERVER_ENABLED);
 
 my $service_file = File::Spec->join( PINITO_DIR, "services" );


### PR DESCRIPTION
For example that allows to execute /bin/bash, when pinito is a container's entrypoint.

Closes #2